### PR TITLE
MOBILE-7088 - recordImpression is not called

### DIFF
--- a/PrebidMobile/Rendering/EventHandlers/PrebidMobileGAMEventHandlers/Sources/GAMBannerEventHandler.swift
+++ b/PrebidMobile/Rendering/EventHandlers/PrebidMobileGAMEventHandlers/Sources/GAMBannerEventHandler.swift
@@ -53,7 +53,7 @@ public class GAMBannerEventHandler :
     }
     
     public func trackImpression() {
-        
+        proxyBanner?.recordImpression()
     }
     
     public func requestAd(with bidResponse: BidResponse?) {


### PR DESCRIPTION
fix: restore impression tracking for GAM banner