### PR TITLE
fix: set correct constants to the AdPosition enum

### DIFF
--- a/PrebidMobile/Rendering/PrebidMobileRendering/PrebidMobileRendering/AdPosition.swift
+++ b/PrebidMobile/Rendering/PrebidMobileRendering/PrebidMobileRendering/AdPosition.swift
@@ -15,10 +15,24 @@
 
 import Foundation
 
+//Ad position on screen. Refer to List 5.4:
+//The following table specifies the position of the ad as a relative measure of visibility or prominence. This
+//OpenRTB table has values derived from the Inventory Quality Guidelines (IQG). Practitioners should
+//keep in sync with updates to the IQG values as published on IAB.com. Values “4” - “7” apply to apps per
+//the mobile addendum to IQG version 2.1.
+//Value Description
+//0 Unknown
+//1 Above the Fold
+//2 DEPRECATED - May or may not be initially visible depending on screen size/resolution.
+//3 Below the Fold
+//4 Header
+//5 Footer
+//6 Sidebar
+//7 Full Screen
 @objc public enum AdPosition: Int {
-    case undefined
-    case header
-    case footer
-    case sidebar
-    case fullScreen 
+    case undefined  = 0 //0 Unknown
+    case header     = 4 //4 Header
+    case footer     = 5 //5 Footer
+    case sidebar    = 6 //6 Sidebar
+    case fullScreen = 7 //7 Full Screen
 }

--- a/PrebidMobile/Rendering/PrebidMobileRendering/PrebidMobileRenderingTests/Prebid/PrebidParameterBuilderTest.swift
+++ b/PrebidMobile/Rendering/PrebidMobileRendering/PrebidMobileRenderingTests/Prebid/PrebidParameterBuilderTest.swift
@@ -72,6 +72,7 @@ class PrebidParameterBuilderTest: XCTestCase {
             .build(bidRequest)
         
         XCTAssertEqual(banner.pos?.intValue, AdPosition.header.rawValue)
+        XCTAssertEqual(banner.pos?.intValue, 4)
     }
     
     func testAdPositionFullScreen() {
@@ -104,6 +105,7 @@ class PrebidParameterBuilderTest: XCTestCase {
             return
         }
         XCTAssertEqual(banner.pos?.intValue, AdPosition.fullScreen.rawValue)
+        XCTAssertEqual(banner.pos?.intValue, 7)
     }
     
     func testAdditionalSizes() {
@@ -175,6 +177,7 @@ class PrebidParameterBuilderTest: XCTestCase {
         PBMAssertEq(video.w, 320)
         PBMAssertEq(video.h, 50)
         XCTAssertEqual(video.pos.intValue, AdPosition.header.rawValue)
+        XCTAssertEqual(video.pos.intValue, 4)
     }
     
     func testNative() {


### PR DESCRIPTION
Fixed values for the AdPosition enum